### PR TITLE
upgrade versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'pl.allegro.tech.build.axion-release' version '1.3.4'
-    id 'com.github.ben-manes.versions' version '0.14.0'
+    id 'pl.allegro.tech.build.axion-release' version '1.8.1'
+    id 'com.github.ben-manes.versions' version '0.17.0'
     id 'publishing'
 }
 

--- a/wiremock-spring-boot-starter/build.gradle
+++ b/wiremock-spring-boot-starter/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'maven'
     id 'maven-publish'
     id 'eclipse'
-    id "com.jfrog.bintray" version '1.7.3'
+    id "com.jfrog.bintray" version '1.8.0'
 }
 
 apply plugin: 'org.springframework.boot'

--- a/wiremock-spring-boot-starter/build.gradle
+++ b/wiremock-spring-boot-starter/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.7.RELEASE'
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.8.RELEASE'
     }
 }
 
@@ -30,7 +30,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-test'
     compile 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
-    compile 'com.github.tomakehurst:wiremock-standalone:2.8.0'
+    compile 'com.github.tomakehurst:wiremock-standalone:2.10.1'
     testCompile 'org.springframework:spring-web'
 }
 

--- a/wiremock/build.gradle
+++ b/wiremock/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'maven'
     id 'maven-publish'
     id 'jacoco'
-    id "com.jfrog.bintray" version '1.7.3'
-    id 'com.github.kt3k.coveralls' version '2.8.1'
+    id "com.jfrog.bintray" version '1.8.0'
+    id 'com.github.kt3k.coveralls' version '2.8.2'
 }
 
 repositories {


### PR DESCRIPTION
I had problems creating a new release. The `restdocs-wiremock` artifact was published to bintray. But the `wiremock-spring-boot-starter` was not.  It could be that the `axion-release` plugin needs an upgrade to work with gradle 4. Let's check. 

@otrosien any thoughts/ideas on this?