### PR TITLE
GH-56 Fix broken bintray upload of wiremock-spring-boot-starter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0"
+    }
+}
+
 plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.8.1'
     id 'com.github.ben-manes.versions' version '0.17.0'
@@ -22,3 +31,6 @@ scmVersion {
 allprojects {
     project.version = scmVersion.version
 }
+
+publish.dependsOn(':restdocs-wiremock:bintrayUpload')
+publish.dependsOn(':wiremock-spring-boot-starter:bintrayUpload')

--- a/wiremock-spring-boot-starter/build.gradle
+++ b/wiremock-spring-boot-starter/build.gradle
@@ -12,10 +12,11 @@ plugins {
     id 'maven'
     id 'maven-publish'
     id 'eclipse'
-    id "com.jfrog.bintray" version '1.8.0'
 }
 
 apply plugin: 'org.springframework.boot'
+
+apply plugin: 'com.jfrog.bintray'
 
 repositories {
     jcenter()
@@ -32,10 +33,6 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
     compile 'com.github.tomakehurst:wiremock-standalone:2.10.1'
     testCompile 'org.springframework:spring-web'
-}
-
-tasks.publish {
-    dependsOn 'bintrayUpload'
 }
 
 task sourceJar(type: Jar) {

--- a/wiremock/build.gradle
+++ b/wiremock/build.gradle
@@ -3,9 +3,10 @@ plugins {
     id 'maven'
     id 'maven-publish'
     id 'jacoco'
-    id "com.jfrog.bintray" version '1.8.0'
     id 'com.github.kt3k.coveralls' version '2.8.2'
 }
+
+apply plugin: 'com.jfrog.bintray'
 
 repositories {
     jcenter()
@@ -34,10 +35,6 @@ jacocoTestReport {
 
 tasks.coveralls {
     dependsOn 'check'
-}
-
-tasks.publish {
-    dependsOn 'bintrayUpload'
 }
 
 task sourceJar(type: Jar) {


### PR DESCRIPTION
by making sure the plugin is on the classpath only once

Addresses #56 