### PR TITLE
add recording mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .settings/
 build/
 bin/
+out/
 gradle.properties

--- a/wiremock-spring-boot-starter/build.gradle
+++ b/wiremock-spring-boot-starter/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
     compile 'com.github.tomakehurst:wiremock-standalone:2.10.1'
-    testCompile 'org.springframework:spring-web'
+    testCompile 'org.springframework.boot:spring-boot-starter-web'
 }
 
 task sourceJar(type: Jar) {

--- a/wiremock-spring-boot-starter/src/main/java/com/epages/wiremock/starter/WireMockProperties.java
+++ b/wiremock-spring-boot-starter/src/main/java/com/epages/wiremock/starter/WireMockProperties.java
@@ -1,5 +1,8 @@
 package com.epages.wiremock.starter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix="wiremock")
@@ -19,6 +22,8 @@ public class WireMockProperties {
 	 * Enables the integration of WireMock in your tests.
 	 */
 	private boolean enabled;
+
+	private List<String> extensions = new ArrayList<>();
 
 	public int getPort() {
 		return port;
@@ -44,5 +49,12 @@ public class WireMockProperties {
 		this.enabled = enabled;
 	}
 
-	
+
+	public List<String> getExtensions() {
+		return extensions;
+	}
+
+	public void setExtensions(List<String> extensions) {
+		this.extensions = extensions;
+	}
 }

--- a/wiremock-spring-boot-starter/src/main/java/com/epages/wiremock/starter/WireMockTest.java
+++ b/wiremock-spring-boot-starter/src/main/java/com/epages/wiremock/starter/WireMockTest.java
@@ -49,4 +49,17 @@ public @interface WireMockTest {
 	 * Sets WireMock to a fixed port. By default WireMock is started on a dynamic port.
 	 */
 	int port() default 0;
+
+	/**
+	 * Should wiremock run in record mode instead of serving stubs
+	 * @return
+	 */
+	boolean record() default false;
+
+	/**
+	 * The target url for recording
+	 * Mandatory in record mode
+	 * @return
+	 */
+	String targetBaseUrl() default "";
 }

--- a/wiremock-spring-boot-starter/src/test/java/com/epages/wiremock/starter/RandomPortSmokeTest.java
+++ b/wiremock-spring-boot-starter/src/test/java/com/epages/wiremock/starter/RandomPortSmokeTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +17,10 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 @WireMockTest
 @SpringBootTest
 @RunWith(SpringRunner.class)
-@Configuration
 public class RandomPortSmokeTest {
 
 	@Autowired
-	public WireMockServer server;
+	private WireMockServer server;
 
 	@Test
 	public void check_server_availability() {

--- a/wiremock-spring-boot-starter/src/test/java/com/epages/wiremock/starter/RecordStubsSmokeTest.java
+++ b/wiremock-spring-boot-starter/src/test/java/com/epages/wiremock/starter/RecordStubsSmokeTest.java
@@ -1,0 +1,90 @@
+package com.epages.wiremock.starter;
+
+import static com.github.tomakehurst.wiremock.recording.RecordingStatus.Recording;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+
+@WireMockTest(port = 8081, record = true, targetBaseUrl = "http://localhost:8082", stubPath = "build/wiremock-stubs")
+@SpringBootTest(
+		classes = {TestApp.class, RecordStubsSmokeTest.ControllerConfiguration.class},
+		webEnvironment = DEFINED_PORT ,
+		properties = "server.port=8082")
+@RunWith(SpringRunner.class)
+public class RecordStubsSmokeTest {
+
+	@Autowired
+	private WireMockServer server;
+
+	@Test
+	public void should_record_mapping() {
+
+		assertThat(server.isRunning()).isTrue();
+		assertThat(server.getRecordingStatus().getStatus()).isEqualTo(Recording);
+		assertThat(server.port()).isEqualTo(8081);
+
+		TestData result = new RestTemplate().postForObject("http://localhost:" + server.port() + "/some", new TestData("some"), TestData.class);
+		assertThat(result).isNotNull();
+		thenMappingRecorded();
+	}
+
+
+	private void thenMappingRecorded() {
+		server.stopRecording();
+		assertThat(getOutputMappingPath()).exists();
+		assertThat(new SingleRootFileSource(getOutputMappingPath().toString()).listFilesRecursively()).hasSize(1);
+	}
+
+	private Path getOutputMappingPath() {
+		return Paths.get("build", "wiremock-stubs", "mappings");
+	}
+
+	@Configuration
+	static class ControllerConfiguration {
+
+		@RestController
+		static class TestController {
+
+			@PostMapping("/some")
+			ResponseEntity<TestData> doSomething(@RequestBody TestData testData) {
+				return ResponseEntity.ok(testData);
+			}
+		}
+	}
+
+	static class TestData {
+		private String some;
+
+		TestData() { }
+
+		TestData(String some) {
+			this.some = some;
+		}
+
+		public String getSome() {
+			return some;
+		}
+
+		public void setSome(String some) {
+			this.some = some;
+		}
+	}
+
+}

--- a/wiremock-spring-boot-starter/src/test/java/com/epages/wiremock/starter/SmokeTest.java
+++ b/wiremock-spring-boot-starter/src/test/java/com/epages/wiremock/starter/SmokeTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +17,10 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 @WireMockTest(port = 8081)
 @SpringBootTest
 @RunWith(SpringRunner.class)
-@Configuration
 public class SmokeTest {
 
 	@Autowired
-	public WireMockServer server;
+	private WireMockServer server;
 
 	@Test
 	public void check_server_availability() {


### PR DESCRIPTION
We found that we have requirements to record wiremock stubs against 3rd party APIs to use them later on in integration tests.

Projects that already use `wiremock-spring-boot-starter` would really benefit if the project can handle recording and stubbing. (handling the dynamic wiremock port, adding WireMockServer as a bean, ease of setup)

What do you think @otrosien @jensfischerhh - is this functionality a good fit here