### PR TITLE
Use URI templates to generate stubs with urlPattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 !.travis.yml
 .settings/
 build/
+out/
 bin/
 gradle.properties

--- a/server/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/server/src/test/java/com/example/notes/ApiDocumentation.java
@@ -53,6 +53,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -219,7 +220,7 @@ public class ApiDocumentation {
 			.andReturn().getResponse().getHeader("Location");
 		
 		this.mockMvc
-			.perform(get(noteLocation))
+				.perform(RestDocumentationRequestBuilders.get("/notes/{id}", noteLocation.substring(noteLocation.lastIndexOf("/") + 1)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("title", is(note.get("title"))))
 			.andExpect(jsonPath("body", is(note.get("body"))))
@@ -338,7 +339,7 @@ public class ApiDocumentation {
 			.andReturn().getResponse().getHeader("Location");
 
 		this.mockMvc
-			.perform(get(tagLocation))
+			.perform(RestDocumentationRequestBuilders.get("/tags/{id}", tagLocation.substring(tagLocation.lastIndexOf("/") + 1)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("name", is(tag.get("name"))))
 			.andDo(this.documentationHandler.document(

--- a/server/src/test/java/com/example/notes/GettingStartedDocumentation.java
+++ b/server/src/test/java/com/example/notes/GettingStartedDocumentation.java
@@ -181,18 +181,6 @@ public class GettingStartedDocumentation {
 				.andExpect(status().isNoContent());
 	}
 
-	MvcResult getTaggedExistingNote(String noteLocation) throws Exception {
-		return this.mockMvc.perform(get(noteLocation))
-			.andExpect(status().isOk())
-			.andReturn();
-	}
-
-	void getTagsForExistingNote(String noteTagsLocation) throws Exception {
-		this.mockMvc.perform(get(noteTagsLocation))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("_embedded.tags", hasSize(1)));
-	}
-
 	private String getLink(MvcResult result, String rel)
 			throws UnsupportedEncodingException {
 		return JsonPath.parse(result.getResponse().getContentAsString()).read(

--- a/wiremock/src/test/java/com/epages/restdocs/WireMockJsonSnippetTest.java
+++ b/wiremock/src/test/java/com/epages/restdocs/WireMockJsonSnippetTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.generate.RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE;
+import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 import java.io.IOException;
 import java.net.URI;
@@ -35,8 +37,6 @@ import org.springframework.restdocs.test.OperationBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-
-import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class WireMockJsonSnippetTest {
 
@@ -76,8 +76,8 @@ public class WireMockJsonSnippetTest {
 	@Test
 	public void simpleRequest() throws IOException {
 		this.expectedSnippet.expectWireMockJson("simple-request").withContents(
-				(Matcher<String>) SameJSONAs
-						.sameJSONAs(new ObjectMapper().writeValueAsString(expectedJsonForSimpleRequest())));
+				(Matcher<String>)
+						sameJSONAs(new ObjectMapper().writeValueAsString(expectedJsonForSimpleRequest())));
 		wiremockJson().document(operationBuilder("simple-request").request("http://localhost/").method("GET").build());
 	}
 
@@ -91,9 +91,29 @@ public class WireMockJsonSnippetTest {
 
 	@SuppressWarnings("unchecked")
 	@Test
+	public void simpleRequestWithUriTemplate() throws IOException {
+		this.expectedSnippet.expectWireMockJson("simple-request").withContents(
+				(Matcher<String>)
+						sameJSONAs(new ObjectMapper().writeValueAsString(expectedJsonForSimpleRequestWithUrlPattern())));
+		wiremockJson().document(operationBuilder("simple-request")
+				.attribute(ATTRIBUTE_NAME_URL_TEMPLATE, "http://localhost/some/{id}/other")
+				.request("http://localhost/some/123-qbc/other")
+				.method("GET").build());
+	}
+
+	private ImmutableMap<String, ImmutableMap<String, ? extends Object>> expectedJsonForSimpleRequestWithUrlPattern() {
+		return of( //
+				"request", //
+				of("method", "GET", "urlPattern", "/some/[^/]+/other"), //
+				"response", //
+				of("headers", emptyMap(), "body", "", "status", 200));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
 	public void getRequestWithParams() throws IOException {
 		this.expectedSnippet.expectWireMockJson("get-request").withContents(
-				(Matcher<String>) SameJSONAs.sameJSONAs(new ObjectMapper().writeValueAsString(
+				(Matcher<String>) sameJSONAs(new ObjectMapper().writeValueAsString(
 						of( //
 								"request", //
 								of("method", "GET", "urlPath", "/foo", "queryParameters", //
@@ -108,8 +128,8 @@ public class WireMockJsonSnippetTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void postRequest() throws IOException {
-		this.expectedSnippet.expectWireMockJson("post-request").withContents((Matcher<String>) SameJSONAs
-				.sameJSONAs(new ObjectMapper().writeValueAsString(
+		this.expectedSnippet.expectWireMockJson("post-request").withContents((Matcher<String>)
+				sameJSONAs(new ObjectMapper().writeValueAsString(
 						of( //
 						"request", //
 						of("method", "POST", "urlPath", "/", "headers", of("Content-Type", of("contains", "uri-list"))), //
@@ -126,8 +146,8 @@ public class WireMockJsonSnippetTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void customMediaType() throws IOException {
-		this.expectedSnippet.expectWireMockJson("custom-mediatype").withContents((Matcher<String>) SameJSONAs
-				.sameJSONAs(new ObjectMapper().writeValueAsString(
+		this.expectedSnippet.expectWireMockJson("custom-mediatype").withContents((Matcher<String>)
+				sameJSONAs(new ObjectMapper().writeValueAsString(
 						of( //
 								"request", //
 								of("method", "GET", "urlPath", "/foo", 


### PR DESCRIPTION
If a URI template is available in the snippet we generate a urlPattern with a regular expression instead of the id in the request. This allows for more flexible request matching when variables are part of the path.